### PR TITLE
Fetch calendar stats for day/week/month

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,13 @@ jobs:
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@v1
 
+      - name: Set time zone to America/Chicago
+        uses: szenius/set-timezone@v1.0
+        with:
+          timezoneLinux: "America/Chicago"
+          timezoneMacos: "America/Chicago"
+          timezoneWindows: "America/Chicago"
+
       - name: Run JS test suite
         run: |
           npm run unitTests -- --maxWorkers ${{ steps.cpu-cores.outputs.count }}

--- a/src/src/components/Contexts/CurrentViewContext.tsx
+++ b/src/src/components/Contexts/CurrentViewContext.tsx
@@ -92,8 +92,16 @@ function resolveBoundaries(
 ): { firstDay: Date; lastDay: Date } {
   if (viewName === 'day')
     return {
-      firstDay: selectedDay,
-      lastDay: selectedDay,
+      firstDay: new Date(
+        selectedDay.getFullYear(),
+        selectedDay.getMonth(),
+        selectedDay.getDate()
+      ),
+      lastDay: new Date(
+        selectedDay.getFullYear(),
+        selectedDay.getMonth(),
+        selectedDay.getDate() + 1
+      ),
     };
   else if (viewName === 'week') {
     const dayOffset = selectedDay.getDate() - selectedDay.getDay();

--- a/src/src/components/Contexts/__tests__/CurrentViewContext.test.ts
+++ b/src/src/components/Contexts/__tests__/CurrentViewContext.test.ts
@@ -12,6 +12,15 @@ const day = testTime.getDate();
 
 theories(parsePath, [
   {
+    in: ['/calendar/u/0/r/day/'],
+    out: {
+      view: 'day',
+      selectedDay: new Date(year, month, day),
+      firstDay: new Date(year, month, day),
+      lastDay: new Date(year, month, day + 1),
+    },
+  },
+  {
     in: ['/calendar/u/0/r/week/'],
     out: {
       view: 'week',

--- a/src/src/components/Core/App.tsx
+++ b/src/src/components/Core/App.tsx
@@ -7,6 +7,7 @@ import { CurrentViewContext } from '../Contexts/CurrentViewContext';
 import { AuthContext } from '../Contexts/AuthContext';
 import { CalendarsContext } from '../Contexts/CalendarsContext';
 import { useAsyncState } from '../../hooks/useAsyncState';
+import { EventsStore, useEvents } from '../EventsStore';
 
 // Allowing for the class to be overridden from here
 const testWidgets: Array<WidgetObj> = [
@@ -37,7 +38,13 @@ export function App(): JSX.Element | null {
   }, []);
 
   const currentView = React.useContext(CurrentViewContext);
-  const auth = React.useContext(AuthContext);
+  const eventsStore = React.useRef<EventsStore>({});
+  const durations = useEvents(
+    eventsStore,
+    // Don't fetch until the overlay is opened
+    isOpen ? currentView?.firstDay : undefined,
+    currentView?.lastDay
+  );
 
   const [debugOverlay] = useAsyncState(
     React.useCallback(() => debugOverlayPromise, []),
@@ -45,6 +52,7 @@ export function App(): JSX.Element | null {
   );
 
   const calendars = React.useContext(CalendarsContext);
+  const auth = React.useContext(AuthContext);
 
   return typeof currentView === 'object' ? (
     <>
@@ -69,7 +77,7 @@ export function App(): JSX.Element | null {
           <main className="h-full overflow-y-auto">
             <Dashboard closeHandler={handleClose} widgets={testWidgets} />
             <pre>
-              {JSON.stringify({ currentView, auth }, null, 4)}
+              {JSON.stringify({ currentView, auth, durations }, null, 4)}
               {JSON.stringify(
                 calendars?.map(({ summary }) => summary) ??
                   commonText('loading'),

--- a/src/src/components/EventsStore/index.test.ts
+++ b/src/src/components/EventsStore/index.test.ts
@@ -1,0 +1,336 @@
+import { theories } from '../../tests/utils';
+import {
+  countDaysBetween,
+  dateToDateTime,
+  dateToString,
+  exportsForTests,
+  getDatesBetween,
+  isMidnight,
+} from './index';
+
+const {
+  calculateBounds,
+  resolveEventDates,
+  extractData,
+  calculateEventDuration,
+  calculateInBetweenDurations,
+} = exportsForTests;
+
+const timeMin = new Date('2022-10-09T05:00:00.000Z');
+const timeMax = new Date('2022-10-16T05:00:00.000Z');
+
+theories(calculateBounds, {
+  'empty cache': {
+    in: [{ current: {} }, 0, timeMin, getDatesBetween(timeMin, timeMax)],
+    out: [timeMin, timeMax],
+  },
+  'non-empty cache': {
+    in: [
+      {
+        current: {
+          '2022-10-9': { 2: 1 },
+          '2022-10-10': { 2: 1, 4: 1 },
+          '2022-10-14': { 3: 4 },
+          '2022-10-15': { 2: 1 },
+          '2022-10-16': { 2: 4 },
+        },
+      },
+      2,
+      timeMin,
+      getDatesBetween(timeMin, timeMax),
+    ],
+    out: [
+      new Date('2022-10-11T05:00:00.000Z'),
+      new Date('2022-10-15T05:00:00.000Z'),
+    ],
+  },
+});
+
+theories(getDatesBetween, [
+  {
+    in: [
+      new Date('2022-10-11T11:00:00-05:00'),
+      new Date('2022-10-11T11:30:00-05:00'),
+    ],
+    out: ['2022-10-11'],
+  },
+  {
+    in: [
+      new Date('2022-10-11T11:00:00-05:00'),
+      new Date('2022-10-11T21:30:00-05:00'),
+    ],
+    out: ['2022-10-11'],
+  },
+  {
+    in: [
+      new Date('2022-10-11T11:00:00-05:00'),
+      new Date('2022-10-21T21:30:00-05:00'),
+    ],
+    out: [
+      '2022-10-11',
+      '2022-10-12',
+      '2022-10-13',
+      '2022-10-14',
+      '2022-10-15',
+      '2022-10-16',
+      '2022-10-17',
+      '2022-10-18',
+      '2022-10-19',
+      '2022-10-20',
+      '2022-10-21',
+    ],
+  },
+  {
+    in: [
+      new Date('2022-10-11T11:00:00-05:00'),
+      new Date('2022-10-21T00:00:00-05:00'),
+    ],
+    out: [
+      '2022-10-11',
+      '2022-10-12',
+      '2022-10-13',
+      '2022-10-14',
+      '2022-10-15',
+      '2022-10-16',
+      '2022-10-17',
+      '2022-10-18',
+      '2022-10-19',
+      '2022-10-20',
+    ],
+  },
+]);
+
+theories(dateToString, [
+  {
+    in: [new Date('2022-10-11T11:00:00-05:00')],
+    out: '2022-10-11',
+  },
+]);
+
+theories(countDaysBetween, [
+  {
+    in: [
+      new Date('2022-10-11T11:00:00-05:00'),
+      new Date('2022-10-11T11:30:00-05:00'),
+    ],
+    out: 1,
+  },
+  {
+    in: [
+      new Date('2022-10-11T11:00:00-05:00'),
+      new Date('2022-10-21T11:30:00-05:00'),
+    ],
+    out: 11,
+  },
+  {
+    in: [
+      new Date('2022-10-11T11:30:00-05:00'),
+      new Date('2022-10-21T00:00:00-05:00'),
+    ],
+    out: 10,
+  },
+]);
+
+theories(isMidnight, [
+  {
+    in: [new Date('2022-10-11T00:00:00-05:00')],
+    out: true,
+  },
+  {
+    in: [new Date('2022-10-11T00:00:01-05:00')],
+    out: false,
+  },
+  {
+    in: [new Date('2022-10-11T00:00:00-00:00')],
+    out: false,
+  },
+]);
+
+theories(resolveEventDates, {
+  'common case': {
+    in: [
+      timeMin,
+      timeMax,
+      {
+        dateTime: '2022-10-11T05:00:00.000Z',
+      },
+      {
+        dateTime: '2022-10-11T06:00:00.000Z',
+      },
+    ],
+    out: [
+      new Date('2022-10-11T05:00:00.000Z'),
+      new Date('2022-10-11T06:00:00.000Z'),
+    ],
+  },
+  'all day event': {
+    in: [
+      timeMin,
+      timeMax,
+      {
+        date: '2022-10-11',
+      },
+      {
+        date: '2022-10-11',
+      },
+    ],
+    out: [
+      new Date('2022-10-11T00:00:00.000-05:00'),
+      new Date('2022-10-12T00:00:00.000-05:00'),
+    ],
+  },
+  'event without end time': {
+    in: [
+      timeMin,
+      timeMax,
+      {
+        dateTime: '2022-10-11T05:00:00.000Z',
+      },
+      {
+        date: '2022-10-11',
+      },
+    ],
+    out: [
+      new Date('2022-10-11T05:00:00.000Z'),
+      new Date('2022-10-12T00:00:00.000-05:00'),
+    ],
+  },
+  'event outside of bounds': {
+    in: [
+      timeMin,
+      timeMax,
+      {
+        date: '2022-01-11',
+      },
+      {
+        date: '2022-11-11',
+      },
+    ],
+    out: [timeMin, timeMax],
+  },
+  'invalid event': {
+    in: [
+      timeMin,
+      timeMax,
+      {},
+      {
+        dateTime: '2022-10-11T06:00:00.000Z',
+      },
+    ],
+    out: undefined,
+  },
+});
+
+theories(dateToDateTime, [
+  {
+    in: ['2020-01-01', 'startDate'],
+    out: new Date('2020-01-01T00:00:00.000-06:00'),
+  },
+  {
+    in: ['2020-01-01', 'endDate'],
+    out: new Date('2020-01-02T00:00:00.000-06:00'),
+  },
+]);
+
+theories(extractData, [
+  {
+    in: [
+      {
+        '2022-10-09': {
+          3: 1,
+          4: 2,
+          5: 4,
+        },
+        '2022-10-10': {
+          3: 1,
+          4: 2,
+        },
+        '2022-10-11': {
+          3: 1,
+          4: 2,
+        },
+        '2022-10-12': {
+          2: 1,
+          3: 1,
+          4: 2,
+        },
+      },
+      [
+        {
+          summary: 'Calendar 3',
+          id: '',
+          shortId: 3,
+        },
+        {
+          summary: 'Calendar 4',
+          id: '',
+          shortId: 4,
+        },
+      ],
+      new Date('2022-10-10T11:00:00-05:00'),
+      new Date('2022-10-12T11:30:00-05:00'),
+    ],
+    out: {
+      '2022-10-10': {
+        3: 1,
+        4: 2,
+      },
+      '2022-10-11': {
+        3: 1,
+        4: 2,
+      },
+      '2022-10-12': {
+        3: 1,
+        4: 2,
+      },
+    },
+  },
+]);
+
+theories(calculateEventDuration, [
+  {
+    name: 'handles case when both dates are on the same day',
+    in: [
+      new Date('2022-10-11T11:00:00-05:00'),
+      new Date('2022-10-11T11:30:00-05:00'),
+    ],
+    out: [['2022-10-11', 30]],
+  },
+  {
+    name: 'calls calculateInBetweenDurations',
+    in: [
+      new Date('2022-10-11T11:00:00-05:00'),
+      new Date('2022-10-12T00:00:00-05:00'),
+    ],
+    out: [['2022-10-11', 780]],
+  },
+]);
+
+theories(calculateInBetweenDurations, [
+  {
+    in: [
+      new Date('2022-10-11T11:00:00-05:00'),
+      new Date('2022-10-12T00:00:00-05:00'),
+    ],
+    out: [['2022-10-11', 780]],
+  },
+  {
+    in: [
+      new Date('2022-10-11T11:00:00-05:00'),
+      new Date('2022-10-21T01:30:00-05:00'),
+    ],
+    out: [
+      ['2022-10-11', 780],
+      ['2022-10-12', 1440],
+      ['2022-10-13', 1440],
+      ['2022-10-14', 1440],
+      ['2022-10-15', 1440],
+      ['2022-10-16', 1440],
+      ['2022-10-17', 1440],
+      ['2022-10-18', 1440],
+      ['2022-10-19', 1440],
+      ['2022-10-20', 1440],
+      ['2022-10-21', 90],
+    ],
+  },
+]);

--- a/src/src/components/EventsStore/index.ts
+++ b/src/src/components/EventsStore/index.ts
@@ -48,7 +48,9 @@ export function useEvents(
           const [timeMin, timeMax] = bounds;
           const response = await ajax(
             formatUrl(
-              `https://www.googleapis.com/calendar/v3/calendars/${id}/events`,
+              `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(
+                id
+              )}/events`,
               {
                 maxAttendees: (1).toString(),
                 // FEATURE: handle pagination (pageToken)

--- a/src/src/components/EventsStore/index.ts
+++ b/src/src/components/EventsStore/index.ts
@@ -1,0 +1,297 @@
+import { useAsyncState } from '../../hooks/useAsyncState';
+import { ajax } from '../../utils/ajax';
+import React from 'react';
+import { CalendarsContext } from '../Contexts/CalendarsContext';
+import { formatUrl } from '../../utils/queryString';
+import { R, RA, WritableArray } from '../../utils/types';
+import { findLastIndex } from '../../utils/utils';
+import {
+  DAY,
+  MILLISECONDS_IN_DAY,
+  MINUTE,
+  MINUTES_IN_DAY,
+} from '../Atoms/Internationalization';
+
+export type EventsStore = R<Record<number, number>>;
+type CalendarEvent = Pick<gapi.client.calendar.Event, 'start' | 'end'>;
+
+// TEST: test daylight savings time switch and back
+/**
+ * Fetch the events between the provided dates for all visible calendars,
+ * calculate the total durations of all events in a given day for a given
+ * calendar, and cache the computations for future use.
+ */
+export function useEvents(
+  eventsStore: React.MutableRefObject<EventsStore>,
+  startDate: Date | undefined,
+  endDate: Date | undefined
+): EventsStore | undefined {
+  const calendars = React.useContext(CalendarsContext);
+  const [loaded] = useAsyncState(
+    React.useCallback(async () => {
+      if (
+        calendars === undefined ||
+        startDate === undefined ||
+        endDate === undefined
+      )
+        return undefined;
+      await Promise.all(
+        calendars.map(async ({ shortId, id }) => {
+          const daysBetween = getDatesBetween(startDate, endDate);
+          const bounds = calculateBounds(
+            eventsStore,
+            shortId,
+            startDate,
+            daysBetween
+          );
+          if (bounds === undefined) return;
+          const [timeMin, timeMax] = bounds;
+          const response = await ajax(
+            formatUrl(
+              `https://www.googleapis.com/calendar/v3/calendars/${id}/events`,
+              {
+                maxAttendees: (1).toString(),
+                // FEATURE: handle pagination (pageToken)
+                maxResults: (2500).toString(),
+                timeMin: timeMin.toJSON(),
+                timeMax: timeMax.toJSON(),
+                prettyPrint: false.toString(),
+                fields: 'items(start(dateTime,date),end(dateTime,date))',
+                // FEATURE: set this to True to reduce response size
+                singleEvents: true.toString(),
+              }
+            )
+          );
+          const results = await response.json();
+          const events = results.items as RA<CalendarEvent>;
+          const durations = events.flatMap(({ start, end }) => {
+            const dates = resolveEventDates(timeMin, timeMax, start, end);
+            if (dates === undefined) return [];
+            const [startDate, endDate] = dates;
+            return calculateEventDuration(startDate, endDate);
+          });
+
+          daysBetween.forEach((dateString) =>
+            calendars.forEach(({ shortId }) => {
+              eventsStore.current[dateString] ??= {};
+              eventsStore.current[dateString][shortId] ??= 0;
+            })
+          );
+          durations.forEach(([dateString, duration]) => {
+            eventsStore.current[dateString][shortId] += duration;
+          });
+        })
+      );
+      return true;
+    }, [calendars, startDate, endDate]),
+    false
+  );
+
+  return React.useMemo(
+    () =>
+      loaded === true &&
+      typeof calendars === 'object' &&
+      typeof startDate === 'object' &&
+      typeof endDate === 'object'
+        ? extractData(eventsStore.current, calendars, startDate, endDate)
+        : undefined,
+    [loaded, calendars, startDate, endDate]
+  );
+}
+
+/**
+ * Find the smallest continuous subset of time in the provided range for which
+ * events haven't been fetched yet.
+ * For example, if events are fetched for the first week of the month, and user
+ * then switches to month view, this function will detect that we only need
+ * to fetch events starting with the second week of the month.
+ */
+function calculateBounds(
+  eventsStore: React.MutableRefObject<EventsStore>,
+  shortId: number,
+  startDate: Date,
+  daysBetween: RA<string>
+): [timeMin: Date, timeMax: Date] | undefined {
+  const firstDayToFetch = daysBetween.findIndex(
+    (day) => eventsStore.current[day]?.[shortId] === undefined
+  );
+  const lastDayToFetch =
+    findLastIndex(
+      daysBetween,
+      (day) => eventsStore.current[day]?.[shortId] === undefined
+    ) + 1;
+  if (firstDayToFetch === -1) return undefined;
+  const timeMin = new Date(startDate);
+  timeMin.setDate(timeMin.getDate() + firstDayToFetch);
+  const timeMax = new Date(startDate);
+  timeMax.setDate(timeMax.getDate() + lastDayToFetch);
+  return [timeMin, timeMax];
+}
+
+/**
+ * Return all dates in between two dates (inclusive) as strings
+ */
+export const getDatesBetween = (startDate: Date, endDate: Date): RA<string> =>
+  Array.from(
+    {
+      length: countDaysBetween(startDate, endDate),
+    },
+    (_, index) => {
+      const date = new Date(startDate);
+      date.setDate(startDate.getDate() + index);
+      return dateToString(date);
+    }
+  );
+
+export const dateToString = (date: Date): string =>
+  `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+
+/**
+ * Count number of dates between two dates (inclusive)
+ */
+export const countDaysBetween = (startDate: Date, endDate: Date): number =>
+  Math.round((endDate.getTime() - startDate.getTime()) / MILLISECONDS_IN_DAY) +
+  // Count the next day, unless it is midnight
+  (isMidnight(endDate) ? 0 : 1);
+
+/**
+ * Checks whether date corresponds to midnight in current time zone
+ */
+export const isMidnight = (date: Date): boolean =>
+  date.getHours() === 0 && date.getMinutes() === 0 && date.getSeconds() === 0;
+
+/**
+ * Event date may be specified as a date or a datetime
+ * Also, event may begin or end outside the bounds of current preview range
+ */
+function resolveEventDates(
+  timeMin: Date,
+  timeMax: Date,
+  start: CalendarEvent['start'],
+  end: CalendarEvent['end']
+) {
+  // Date is defined instead of DateTime for multi-day events
+  const unboundedStartDate =
+    typeof start.dateTime === 'string'
+      ? new Date(start.dateTime)
+      : typeof start.date === 'string'
+      ? dateToDateTime(start.date, 'startDate')
+      : undefined;
+  const unboundedEndDate =
+    typeof end.dateTime === 'string'
+      ? new Date(end.dateTime)
+      : typeof end.date === 'string'
+      ? dateToDateTime(end.date, 'endDate')
+      : undefined;
+
+  if (unboundedStartDate === undefined || unboundedEndDate === undefined)
+    return undefined;
+
+  // Multi-date events might begin/end outside of current preview range
+  const startDate = new Date(
+    Math.max(unboundedStartDate.getTime(), timeMin.getTime())
+  );
+  const endDate = new Date(
+    Math.min(unboundedEndDate.getTime(), timeMax.getTime())
+  );
+  return [startDate, endDate];
+}
+
+/**
+ * Convert date to dateTime (using midnight in current time zone)
+ */
+export function dateToDateTime(
+  dateString: string,
+  type: 'startDate' | 'endDate'
+): Date {
+  const date = new Date(dateString);
+  if (type === 'endDate') date.setDate(date.getDate() + 1);
+  // FEATURE: time zone support (use calendar time zone)
+  date.setHours(24);
+  return date;
+}
+
+/**
+ * Extract data for the fetched date range for the visible calendars from the
+ * events store
+ */
+function extractData(
+  eventsStore: EventsStore,
+  calendars: Exclude<React.ContextType<typeof CalendarsContext>, undefined>,
+  startDate: Date,
+  endDate: Date
+): EventsStore {
+  const daysBetween = getDatesBetween(startDate, endDate);
+  return Object.fromEntries(
+    daysBetween.map((day) => [
+      day,
+      Object.fromEntries(
+        calendars.map(({ shortId }) => [
+          shortId,
+          eventsStore[day]?.[shortId] ?? 0,
+        ])
+      ),
+    ])
+  );
+}
+
+/**
+ * Calculate number of minutes between two days, split into 24-hour chunks
+ * Handles the case when both dates are on the same day
+ */
+function calculateEventDuration(startDate: Date, endDate: Date) {
+  const daySpan = countDaysBetween(startDate, endDate);
+  if (Number.isNaN(daySpan)) [];
+
+  if (daySpan === 1) {
+    const duration = (endDate.getTime() - startDate.getTime()) / MINUTE;
+    return [[dateToString(startDate), duration]] as const;
+  } else return calculateInBetweenDurations(startDate, endDate);
+}
+
+/**
+ * Calculate number of minutes between two dates, split into 24-hour chunks
+ * Expects endDate to not be on the same day as startDate
+ */
+function calculateInBetweenDurations(
+  startDate: Date,
+  endDate: Date
+): RA<readonly [string, number]> {
+  const results: WritableArray<readonly [string, number]> = [];
+
+  // First Day
+  const firstDayStart = new Date(startDate);
+  firstDayStart.setHours(0);
+  firstDayStart.setMinutes(0);
+  firstDayStart.setSeconds(0);
+  const firstDayDuration =
+    (DAY - (startDate.getTime() - firstDayStart.getTime())) / MINUTE;
+  results.push([dateToString(startDate), firstDayDuration]);
+
+  // Full days
+  const datesBetween = getDatesBetween(startDate, endDate).slice(
+    1,
+    isMidnight(endDate) ? undefined : -1
+  );
+  datesBetween.forEach((dateString) =>
+    results.push([dateString, MINUTES_IN_DAY])
+  );
+
+  // Last Day
+  const lastDayStart = new Date(endDate);
+  lastDayStart.setHours(0);
+  lastDayStart.setMinutes(0);
+  lastDayStart.setSeconds(0);
+  const lastDayDuration = (endDate.getTime() - lastDayStart.getTime()) / MINUTE;
+  if (lastDayDuration !== 0)
+    results.push([dateToString(endDate), lastDayDuration]);
+  return results;
+}
+
+export const exportsForTests = {
+  calculateBounds,
+  resolveEventDates,
+  extractData,
+  calculateEventDuration,
+  calculateInBetweenDurations,
+};

--- a/src/src/tests/__tests__/globalSetup.test.ts
+++ b/src/src/tests/__tests__/globalSetup.test.ts
@@ -1,0 +1,8 @@
+test('make sure tests are running under correct time zone', () => {
+  expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe(
+    'America/Chicago'
+  );
+  expect(new Date().getTimezoneOffset()).toBe(300);
+});
+
+export {};


### PR DESCRIPTION
Fetch calendar events for day/week/month for all visible calendars and compute the event durations for each day.

Also, caches computed durations and handles all-day and multi-day events.

Fetched data for visible calendars only, but detects when another calendar is enabled and fetches data if necessary.

Fetched only the data that hasn't already been fetched, thus going back and forth between two weeks won't send excessive API calls