### PR TITLE
Setting escape to open and close

### DIFF
--- a/src/src/components/Core/App.tsx
+++ b/src/src/components/Core/App.tsx
@@ -21,15 +21,17 @@ const debugOverlayPromise =
     : undefined;
 
 export function App(): JSX.Element | null {
-  const [isOpen, _, handleClose, handleToggle] = useBooleanState();
+  const [isOpen, _, __, handleToggle] = useBooleanState();
 
   React.useEffect(() => {
     const handleEscKey = (event: KeyboardEvent): void =>
-      event.key === 'Escape' ? handleClose() : undefined;
+      event.key === 'Escape' ? handleToggle() : undefined;
 
     document.addEventListener('keydown', handleEscKey, false);
 
-    return () => document.removeEventListener('keydown', handleEscKey, false);
+    return () => {
+      document.removeEventListener('keydown', handleEscKey, false);
+    };
   }, []);
 
   const currentView = React.useContext(CurrentViewContext);

--- a/src/src/components/Core/App.tsx
+++ b/src/src/components/Core/App.tsx
@@ -24,13 +24,13 @@ export function App(): JSX.Element | null {
   const [isOpen, _, __, handleToggle] = useBooleanState();
 
   React.useEffect(() => {
-    const handleEscKey = (event: KeyboardEvent): void =>
-      event.key === 'Escape' ? handleToggle() : undefined;
+    const handleBackTickKey = (event: KeyboardEvent): void =>
+      event.key === '`' ? handleToggle() : undefined;
 
-    document.addEventListener('keydown', handleEscKey, false);
+    document.addEventListener('keydown', handleBackTickKey, false);
 
     return () => {
-      document.removeEventListener('keydown', handleEscKey, false);
+      document.removeEventListener('keydown', handleBackTickKey, false);
     };
   }, []);
 


### PR DESCRIPTION
I feel like this might be the best solution. It is nice to have the same key for both opening and closing.

One slight worry I have would be accessibility regarding overriding the 'escape' key on the main page, but I could not see any direct conflicts immediately. I do not use calendar frequently though, so I did not necessarily know where to look.