### PR TITLE
Add ability to assign shorter names to calendars

### DIFF
--- a/src/src/components/Dashboard/Widget.tsx
+++ b/src/src/components/Dashboard/Widget.tsx
@@ -12,6 +12,7 @@ import { RR } from '../../utils/types';
 import { icon } from '../Atoms/Icon';
 import { Button } from '../Atoms';
 import { VirtualCalendars } from '../Widgets/VirtualCalendars';
+import { Shortcuts } from '../Widgets/Shortcuts';
 
 const widgets = {
   DoughnutChart,
@@ -21,6 +22,7 @@ const widgets = {
   QuickActions,
   Suggestions,
   VirtualCalendars,
+  Shortcuts,
 } as const;
 
 export const widgetLabels: RR<keyof typeof widgets, string> = {
@@ -31,6 +33,7 @@ export const widgetLabels: RR<keyof typeof widgets, string> = {
   QuickActions: commonText('quickActions'),
   Suggestions: commonText('suggestions'),
   VirtualCalendars: commonText('virtualCalendars'),
+  Shortcuts: commonText('shortNames'),
 };
 
 export function WidgetContent({

--- a/src/src/components/Dashboard/Widget.tsx
+++ b/src/src/components/Dashboard/Widget.tsx
@@ -12,7 +12,7 @@ import { RR } from '../../utils/types';
 import { icon } from '../Atoms/Icon';
 import { Button } from '../Atoms';
 import { VirtualCalendars } from '../Widgets/VirtualCalendars';
-import { Shortcuts } from '../Widgets/Shortcuts';
+import { Synonyms } from '../Widgets/Synonyms';
 
 const widgets = {
   DoughnutChart,
@@ -22,7 +22,7 @@ const widgets = {
   QuickActions,
   Suggestions,
   VirtualCalendars,
-  Shortcuts,
+  Shortcuts: Synonyms,
 } as const;
 
 export const widgetLabels: RR<keyof typeof widgets, string> = {

--- a/src/src/components/Dashboard/definitions.tsx
+++ b/src/src/components/Dashboard/definitions.tsx
@@ -76,69 +76,6 @@ export const defaultLayout: RA<WidgetDefinition> = [
   },
   {
     colSpan: {
-      '2xl': 2,
-      lg: 2,
-      md: 3,
-      sm: 1,
-      xl: 2,
-      xs: 1,
-    },
-    rowSpan: {
-      '2xl': 1,
-      lg: 1,
-      md: 1,
-      sm: 1,
-      xl: 1,
-      xs: 1,
-    },
-    definition: {
-      type: 'DataExport',
-    },
-  },
-  {
-    colSpan: {
-      '2xl': 1,
-      lg: 1,
-      md: 3,
-      sm: 1,
-      xl: 1,
-      xs: 1,
-    },
-    rowSpan: {
-      '2xl': 1,
-      lg: 1,
-      md: 1,
-      sm: 1,
-      xl: 1,
-      xs: 1,
-    },
-    definition: {
-      type: 'Suggestions',
-    },
-  },
-  {
-    colSpan: {
-      '2xl': 1,
-      lg: 1,
-      md: 3,
-      sm: 1,
-      xl: 1,
-      xs: 1,
-    },
-    rowSpan: {
-      '2xl': 1,
-      lg: 1,
-      md: 1,
-      sm: 2,
-      xl: 1,
-      xs: 1,
-    },
-    definition: {
-      type: 'QuickActions',
-    },
-  },
-  {
-    colSpan: {
       xs: 1,
       sm: 1,
       md: 3,
@@ -150,12 +87,96 @@ export const defaultLayout: RA<WidgetDefinition> = [
       xs: 1,
       sm: 1,
       md: 1,
+      lg: 7,
+      xl: 11,
+      '2xl': 9,
+    },
+    definition: {
+      type: 'VirtualCalendars',
+    },
+  },
+  {
+    colSpan: {
+      xs: 1,
+      sm: 1,
+      md: 1,
+      lg: 2,
+      xl: 2,
+      '2xl': 2,
+    },
+    rowSpan: {
+      xs: 1,
+      sm: 1,
+      md: 1,
       lg: 1,
       xl: 1,
       '2xl': 1,
     },
     definition: {
-      type: 'VirtualCalendars',
+      type: 'DataExport',
+    },
+  },
+  {
+    colSpan: {
+      xs: 1,
+      sm: 1,
+      md: 2,
+      lg: 2,
+      xl: 2,
+      '2xl': 2,
+    },
+    rowSpan: {
+      xs: 1,
+      sm: 1,
+      md: 1,
+      lg: 1,
+      xl: 1,
+      '2xl': 1,
+    },
+    definition: {
+      type: 'Shortcuts',
+    },
+  },
+  {
+    colSpan: {
+      xs: 1,
+      sm: 1,
+      md: 2,
+      lg: 2,
+      xl: 2,
+      '2xl': 2,
+    },
+    rowSpan: {
+      xs: 1,
+      sm: 1,
+      md: 1,
+      lg: 1,
+      xl: 1,
+      '2xl': 1,
+    },
+    definition: {
+      type: 'QuickActions',
+    },
+  },
+  {
+    colSpan: {
+      xs: 1,
+      sm: 1,
+      md: 1,
+      lg: 2,
+      xl: 2,
+      '2xl': 2,
+    },
+    rowSpan: {
+      xs: 1,
+      sm: 1,
+      md: 1,
+      lg: 1,
+      xl: 1,
+      '2xl': 1,
+    },
+    definition: {
+      type: 'Suggestions',
     },
   },
 ];

--- a/src/src/components/Dashboard/index.tsx
+++ b/src/src/components/Dashboard/index.tsx
@@ -27,7 +27,8 @@ export type WidgetDefinition = {
     | State<'QuickActions'>
     | State<'StackedChart'>
     | State<'Suggestions'>
-    | State<'VirtualCalendars'>;
+    | State<'VirtualCalendars'>
+    | State<'Shortcuts'>;
 };
 
 const widgetClassName = `

--- a/src/src/components/PowerTools/AutoComplete.tsx
+++ b/src/src/components/PowerTools/AutoComplete.tsx
@@ -14,11 +14,16 @@ export function AutoComplete(): JSX.Element {
   const calendars = React.useContext(CalendarsContext);
 
   const virtualCalendars = useVirtualCalendars();
-
   const virtualCalendarsRef = React.useRef(virtualCalendars);
   React.useEffect(() => {
     virtualCalendarsRef.current = virtualCalendars;
   }, [virtualCalendars]);
+
+  const [shortcuts = []] = useSafeStorage('shortcuts', []);
+  const shortcutsRef = React.useRef(shortcuts);
+  React.useEffect(() => {
+    shortcutsRef.current = shortcuts;
+  }, [shortcuts]);
 
   const dataListId = useId('autocomplete-list')('');
 
@@ -45,15 +50,25 @@ export function AutoComplete(): JSX.Element {
           element.removeEventListener('blur', blurListeners.get(element)!);
           blurListeners.delete(element);
 
-          const calendarId = guessCalendar(element.value.trim());
-          if (typeof calendarId === 'undefined') return;
+          const eventName = element.value.trim();
+          let calendarId = guessCalendar(eventName);
+          if (calendarId === undefined) {
+            const guessShortcut = shortcutsRef.current.find(({ shortcut }) =>
+              eventName.startsWith(`${shortcut}:`)
+            );
+            if (guessShortcut === undefined) return;
+            calendarId = guessShortcut.calendar;
+            element.value = eventName
+              .slice(guessShortcut.shortcut.length + 1)
+              .trim();
+          }
 
           const parent = findParent(element);
           if (parent === undefined) return;
           const select = findCalendarSelector(parent);
           if (select === undefined) return;
           waitAndClick(parent, select, () => {
-            const option = findOption(calendars!, calendarId, select);
+            const option = findOption(calendars!, calendarId!, select);
             option.click();
             // The option click is not registering if focusing the input too soon
             setTimeout(() => element.focus(), 200);

--- a/src/src/components/PowerTools/AutoComplete.tsx
+++ b/src/src/components/PowerTools/AutoComplete.tsx
@@ -19,11 +19,11 @@ export function AutoComplete(): JSX.Element {
     virtualCalendarsRef.current = virtualCalendars;
   }, [virtualCalendars]);
 
-  const [shortcuts = []] = useSafeStorage('shortcuts', []);
-  const shortcutsRef = React.useRef(shortcuts);
+  const [synonyms = []] = useSafeStorage('synonyms', []);
+  const synonymsRef = React.useRef(synonyms);
   React.useEffect(() => {
-    shortcutsRef.current = shortcuts;
-  }, [shortcuts]);
+    synonymsRef.current = synonyms;
+  }, [synonyms]);
 
   const dataListId = useId('autocomplete-list')('');
 
@@ -53,13 +53,13 @@ export function AutoComplete(): JSX.Element {
           const eventName = element.value.trim();
           let calendarId = guessCalendar(eventName);
           if (calendarId === undefined) {
-            const guessShortcut = shortcutsRef.current.find(({ shortcut }) =>
-              eventName.startsWith(`${shortcut}:`)
+            const guessSynonym = synonymsRef.current.find(({ synonym }) =>
+              eventName.startsWith(`${synonym}:`)
             );
-            if (guessShortcut === undefined) return;
-            calendarId = guessShortcut.calendar;
+            if (guessSynonym === undefined) return;
+            calendarId = guessSynonym.calendar;
             element.value = eventName
-              .slice(guessShortcut.shortcut.length + 1)
+              .slice(guessSynonym.synonym.length + 1)
               .trim();
           }
 

--- a/src/src/components/Widgets/Shortcuts.tsx
+++ b/src/src/components/Widgets/Shortcuts.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+
+import { useSafeStorage } from '../../hooks/useStorage';
+import { commonText } from '../../localization/common';
+import { removeItem, replaceItem } from '../../utils/utils';
+import { Button, Input } from '../Atoms';
+import { icon } from '../Atoms/Icon';
+import { CalendarsContext } from '../Contexts/CalendarsContext';
+import { CalendarIndicator } from '../Molecules/CalendarIndicator';
+import { CalendarList } from '../Molecules/CalendarList';
+import { WidgetContainer } from './WidgetContainer';
+
+export type Shortcut = {
+  readonly calendar: string;
+  readonly shortcut: string;
+};
+
+export function Shortcuts({ label }: { readonly label: string }): JSX.Element {
+  const [shortcuts, setShortcuts] = useSafeStorage('shortcuts', []);
+  const editing = React.useState<boolean>(false);
+  const [isEditing] = editing;
+  const calendars = React.useContext(CalendarsContext);
+  return (
+    <WidgetContainer editing={editing} header={label}>
+      {Array.isArray(calendars) && Array.isArray(shortcuts) ? (
+        <table className="text-left">
+          <thead>
+            <tr>
+              <td />
+              <th scope="col">{commonText('calendar')}</th>
+              <th scope="col">{commonText('shortName')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {shortcuts.map(({ calendar: calendarId, shortcut }, index) => {
+              const calendar = calendars.find(({ id }) => id === calendarId);
+              if (calendar === undefined) return undefined;
+              return (
+                <tr key={index}>
+                  <td>
+                    {isEditing ? (
+                      <Button.Red
+                        aria-label={commonText('remove')}
+                        className="!p-1"
+                        title={commonText('remove')}
+                        onClick={(): void =>
+                          setShortcuts(removeItem(shortcuts, index))
+                        }
+                      >
+                        {icon.trash}
+                      </Button.Red>
+                    ) : (
+                      <CalendarIndicator color={calendar.backgroundColor} />
+                    )}
+                  </td>
+                  <td>
+                    {isEditing ? (
+                      <CalendarList
+                        calendars={calendars}
+                        value={calendar.id}
+                        onChange={(calendar): void =>
+                          setShortcuts(
+                            replaceItem(shortcuts, index, {
+                              calendar,
+                              shortcut,
+                            })
+                          )
+                        }
+                      />
+                    ) : (
+                      calendar.summary
+                    )}
+                  </td>
+                  <td>
+                    {isEditing ? (
+                      <Input.Text
+                        value={shortcut}
+                        onValueChange={(shortcut): void =>
+                          setShortcuts(
+                            replaceItem(shortcuts, index, {
+                              calendar: calendarId,
+                              shortcut,
+                            })
+                          )
+                        }
+                      />
+                    ) : (
+                      shortcut
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+            {isEditing && (
+              <tr>
+                <td />
+                <td colSpan={2}>
+                  <Button.White
+                    onClick={(): void =>
+                      setShortcuts([
+                        ...shortcuts,
+                        { calendar: calendars[0].id, shortcut: '' },
+                      ])
+                    }
+                  >
+                    {commonText('add')}
+                  </Button.White>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      ) : (
+        commonText('loading')
+      )}
+    </WidgetContainer>
+  );
+}

--- a/src/src/components/Widgets/Synonyms.tsx
+++ b/src/src/components/Widgets/Synonyms.tsx
@@ -10,19 +10,19 @@ import { CalendarIndicator } from '../Molecules/CalendarIndicator';
 import { CalendarList } from '../Molecules/CalendarList';
 import { WidgetContainer } from './WidgetContainer';
 
-export type Shortcut = {
+export type Synonym = {
   readonly calendar: string;
-  readonly shortcut: string;
+  readonly synonym: string;
 };
 
-export function Shortcuts({ label }: { readonly label: string }): JSX.Element {
-  const [shortcuts, setShortcuts] = useSafeStorage('shortcuts', []);
+export function Synonyms({ label }: { readonly label: string }): JSX.Element {
+  const [synonyms, setSynonyms] = useSafeStorage('synonyms', []);
   const editing = React.useState<boolean>(false);
   const [isEditing] = editing;
   const calendars = React.useContext(CalendarsContext);
   return (
     <WidgetContainer editing={editing} header={label}>
-      {Array.isArray(calendars) && Array.isArray(shortcuts) ? (
+      {Array.isArray(calendars) && Array.isArray(synonyms) ? (
         <table className="text-left">
           <thead>
             <tr>
@@ -32,7 +32,7 @@ export function Shortcuts({ label }: { readonly label: string }): JSX.Element {
             </tr>
           </thead>
           <tbody>
-            {shortcuts.map(({ calendar: calendarId, shortcut }, index) => {
+            {synonyms.map(({ calendar: calendarId, synonym }, index) => {
               const calendar = calendars.find(({ id }) => id === calendarId);
               if (calendar === undefined) return undefined;
               return (
@@ -44,7 +44,7 @@ export function Shortcuts({ label }: { readonly label: string }): JSX.Element {
                         className="!p-1"
                         title={commonText('remove')}
                         onClick={(): void =>
-                          setShortcuts(removeItem(shortcuts, index))
+                          setSynonyms(removeItem(synonyms, index))
                         }
                       >
                         {icon.trash}
@@ -59,10 +59,10 @@ export function Shortcuts({ label }: { readonly label: string }): JSX.Element {
                         calendars={calendars}
                         value={calendar.id}
                         onChange={(calendar): void =>
-                          setShortcuts(
-                            replaceItem(shortcuts, index, {
+                          setSynonyms(
+                            replaceItem(synonyms, index, {
                               calendar,
-                              shortcut,
+                              synonym,
                             })
                           )
                         }
@@ -74,18 +74,18 @@ export function Shortcuts({ label }: { readonly label: string }): JSX.Element {
                   <td>
                     {isEditing ? (
                       <Input.Text
-                        value={shortcut}
-                        onValueChange={(shortcut): void =>
-                          setShortcuts(
-                            replaceItem(shortcuts, index, {
+                        value={synonym}
+                        onValueChange={(synonym): void =>
+                          setSynonyms(
+                            replaceItem(synonyms, index, {
                               calendar: calendarId,
-                              shortcut,
+                              synonym,
                             })
                           )
                         }
                       />
                     ) : (
-                      shortcut
+                      synonym
                     )}
                   </td>
                 </tr>
@@ -97,9 +97,9 @@ export function Shortcuts({ label }: { readonly label: string }): JSX.Element {
                 <td colSpan={2}>
                   <Button.White
                     onClick={(): void =>
-                      setShortcuts([
-                        ...shortcuts,
-                        { calendar: calendars[0].id, shortcut: '' },
+                      setSynonyms([
+                        ...synonyms,
+                        { calendar: calendars[0].id, synonym: '' },
                       ])
                     }
                   >

--- a/src/src/hooks/useStorage.tsx
+++ b/src/src/hooks/useStorage.tsx
@@ -10,7 +10,7 @@ import { f } from '../utils/functools';
 import type { GetSet, RA, RR } from '../utils/types';
 import { setDevelopmentGlobal } from '../utils/types';
 import { useAsyncState } from './useAsyncState';
-import { Shortcut } from '../components/Widgets/Shortcuts';
+import { Synonym } from '../components/Widgets/Synonyms';
 
 export type StorageDefinitions = {
   readonly layout: RA<WidgetDefinition>;
@@ -22,7 +22,7 @@ export type StorageDefinitions = {
   readonly overSizeStorage: RA<string>;
   readonly storageVersions: Partial<RR<keyof StorageDefinitions, string>>;
   readonly customViewSize: number;
-  readonly shortcuts: RA<Shortcut>;
+  readonly synonyms: RA<Synonym>;
 };
 
 /**

--- a/src/src/hooks/useStorage.tsx
+++ b/src/src/hooks/useStorage.tsx
@@ -10,6 +10,7 @@ import { f } from '../utils/functools';
 import type { GetSet, RA, RR } from '../utils/types';
 import { setDevelopmentGlobal } from '../utils/types';
 import { useAsyncState } from './useAsyncState';
+import { Shortcut } from '../components/Widgets/Shortcuts';
 
 export type StorageDefinitions = {
   readonly layout: RA<WidgetDefinition>;
@@ -21,6 +22,7 @@ export type StorageDefinitions = {
   readonly overSizeStorage: RA<string>;
   readonly storageVersions: Partial<RR<keyof StorageDefinitions, string>>;
   readonly customViewSize: number;
+  readonly shortcuts: RA<Shortcut>;
 };
 
 /**

--- a/src/src/localization/common.tsx
+++ b/src/src/localization/common.tsx
@@ -55,6 +55,8 @@ export const commonText = createDictionary({
   allCategories: { 'en-us': 'All Categories' },
   addPrediction: { 'en-us': 'Add Prediction' },
   noVirtualCalendars: { 'en-us': 'No virtual calendars configured' },
+  shortName: { 'en-us': 'Short Name' },
+  shortNames: { 'en-us': 'Short Names' },
 });
 /* eslint-enable react/jsx-no-literals */
 /* eslint-enable @typescript-eslint/naming-convention */


### PR DESCRIPTION
The names of calendars can be several words long.
For the sake of saving time, having a much shorter synonym name for a calendar is useful (i.e a single character)

The synonym can then be used by the autocomplete component, and in the future, by other widgets.

This PR:
- Added UI for defining synonyms
- Added synonyms widget to default layout
- Integrated automatic calendar picker logic with synonyms

Example workflow for a user:
Define a shortcut `w` for the `Work` calendar.
Try to create a new event
In the event name, enter `w:Some event name`.
The extension automatically picks the `Work` calendar for this event, and strips the `w:` from the event name.